### PR TITLE
include "main" property in package for use in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "angular schema form base64 file add-on for Angular Schema Form.",
   "author": "Textalk",
   "license": "MIT",
+  "main": "dist/angular-schema-form-base64-file-upload.min.js",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-angular-templatecache": "^1.8.0",


### PR DESCRIPTION
Webpack requires the main property to be defined as the entry point for the module.

A workaround is to 'import' the main file directly, but this isn't very ES6 like.

Thanks!
